### PR TITLE
Fix: main__top--text height로 인하여 드롭다운 헤더가 안 눌리는 오류

### DIFF
--- a/components/Main/styles.tsx
+++ b/components/Main/styles.tsx
@@ -43,7 +43,6 @@ export const MainDiv = styled.div`
 
   .main__top--text {
     display: flex;
-    height: 90%;
     flex-direction: column;
     justify-content: center;
     animation: ${textAppear} 7s ease-in-out infinite;


### PR DESCRIPTION
홈화면 윗부분 텍스트 height 때문에 헤더가 안 눌리는 에러를 해결했습니다.