### PR TITLE
Fix-Word: 메타태그  이미지 파일에 확장자를 뺴먹어 수정

### DIFF
--- a/components/HeadMeta/index.tsx
+++ b/components/HeadMeta/index.tsx
@@ -12,7 +12,7 @@ const HeadMeta = ({ title, description, image, url }) => {
       <meta property="og:type" content="website" />
       <meta property="og:title" content={title || '시퀀스'} />
       <meta property="og:description" content={description || '프로젝트 동아리 시퀀스'} />
-      <meta property="og:image" content={image || "'/sqMakesD"} />
+      <meta property="og:image" content={image || '/sqMakesD.png'} />
       <meta property="og:url" content={url || 'https://sequence.cbnu.ac.kr'} />
       <meta httpEquiv="Author" content={'naamukim,geunu97,songhaeunsong,songhee99'} />
       <meta name="Keywords" content="시퀀스, 프로젝트 동아리, 웹 개발" />


### PR DESCRIPTION
이미지 확장자를 적지 않아 meta태그가 먹지 않는 오류가 있었습니다. 수정하였습니다.